### PR TITLE
require diff-mode for both diff-added and diff-removed faces

### DIFF
--- a/ibuffer-git.el
+++ b/ibuffer-git.el
@@ -32,6 +32,7 @@
 ;;; Code:
 
 (require 'ibuffer)
+(require 'diff-mode)
 (require 'cl)
 
 (defgroup ibuffer-git nil


### PR DESCRIPTION
Unless you already have loaded diff-mode, you won't get colored
pluses (+++) and minuses (---) on the git-status column because
ibuffer-git-add-face and ibuffer-git-del-face inherits diff-added and
diff-removed faces.

So, just require it.